### PR TITLE
backport irq fixes + libretro interlace fix

### DIFF
--- a/cpu.cpp
+++ b/cpu.cpp
@@ -232,7 +232,6 @@ static void S9xSoftResetCPU (void)
 	CPU.IRQLine = FALSE;
 	CPU.IRQTransition = FALSE;
 	CPU.IRQExternal = FALSE;
-	CPU.IRQPending = Timings.IRQPendCount;
 	CPU.MemSpeed = SLOW_ONE_CYCLE;
 	CPU.MemSpeedx2 = SLOW_ONE_CYCLE * 2;
 	CPU.FastROMSpeed = SLOW_ONE_CYCLE;

--- a/cpuexec.cpp
+++ b/cpuexec.cpp
@@ -257,8 +257,6 @@ void S9xMainLoop (void)
 					S9xDoHEventProcessing();
 			}
 
-
-			CPU.IRQPending = Timings.IRQPendCount;
 			CPU.IRQTransition = FALSE;
 			CPU.IRQLine = TRUE;
 		}
@@ -267,12 +265,10 @@ void S9xMainLoop (void)
 		{
 			S9xUpdateIRQPositions(false);
 
-			if (CPU.IRQPending)
-				CPU.IRQPending--;
-			else
-			{
-				CPU.IRQTransition = TRUE;
-			}
+		#ifdef DEBUGGER
+			S9xTraceMessage ("Timer triggered\n");
+		#endif
+			CPU.IRQTransition = TRUE;
 		}
 
 		if ((CPU.IRQLine || CPU.IRQExternal) && !CheckFlag(IRQ))

--- a/cpuops.cpp
+++ b/cpuops.cpp
@@ -1637,7 +1637,10 @@ static void Op58 (void)
 {
 	ClearIRQ();
 	AddCycles(ONE_CYCLE);
-	CHECK_FOR_IRQ();
+
+#ifndef SA1_OPCODES
+        CPU.IRQLine = FALSE;
+#endif
 }
 
 // SEI

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -724,8 +724,10 @@ void S9xUpdateScreen (void)
 				GFX.PPL = GFX.RealPPL << 1;
 				GFX.DoInterlace = 2;
 
-				for (register int32 y = (int32) GFX.StartY - 1; y >= 0; y--)
-					memmove(GFX.Screen + y * GFX.PPL, GFX.Screen + y * GFX.RealPPL, IPPU.RenderedScreenWidth * sizeof(uint16));
+				for (register int32 y = (int32) GFX.StartY - 2; y >= 0; y--)
+					memmove (GFX.Screen + (y+1) * GFX.PPL,
+							 GFX.Screen + (y+0) * GFX.RealPPL,
+							 GFX.Pitch*sizeof(uint16));
 			}
 		}
 

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -2724,7 +2724,6 @@ void CMemory::InitROM (void)
 	   and the NMI handler, time enough for an instruction or two. */
 	// Wild Guns, Mighty Morphin Power Rangers - The Fighting Edition
 	Timings.NMIDMADelay  = 24;
-	Timings.IRQPendCount = 0;
 
 	IPPU.TotalEmulatedFrames = 0;
 
@@ -3000,8 +2999,8 @@ void CMemory::map_LoROMSRAM (void)
 {
         uint32 hi;
 
-				// libretro fork: Deae Tonosama - Appare Ichiban (Japan) copier protection
-				if( SRAMSize == 0 ) return;
+        // libretro fork: Deae Tonosama - Appare Ichiban (Japan) copier protection
+        if( SRAMSize == 0 ) return;
 
 
         if (ROMSize > 11 || SRAMSize > 5)
@@ -3851,19 +3850,6 @@ void CMemory::ApplyROMFixes (void)
 
 	if (!Settings.DisableGameSpecificHacks)
 	{
-		// An infinite loop reads $4212 and waits V-blank end, whereas VIRQ is set V=0.
-		// If Snes9x succeeds to escape from the loop before jumping into the IRQ handler, the game goes further.
-		// If Snes9x jumps into the IRQ handler before escaping from the loop,
-		// Snes9x cannot escape from the loop permanently because the RTI is in the next V-blank.
-		if (match_na("Aero the AcroBat 2"))
-		{
-			Timings.IRQPendCount = 2;
-			if (log_cb) log_cb(RETRO_LOG_INFO, "IRQ count hack: %d\n", Timings.IRQPendCount);
-		}
-	}
-
-	if (!Settings.DisableGameSpecificHacks)
-	{
 		// smp transfer loop problem
 		if (match_na("LITTLE MAGIC") ||
 			  match_nc("Little Magic (Europe)") ||
@@ -3878,26 +3864,6 @@ void CMemory::ApplyROMFixes (void)
 			}
 		}
 	}
-
-	if (!Settings.DisableGameSpecificHacks)
-	{
-		// irq cli problem
-		if (match_nn("MARKOS MAGIC FOOTBALL"))
-		{
-			unsigned char patch1[] = {0x78,0x08,0xC2,0x30,0x48,0xDA,0x5A,0x8B,0x0B,0xE2,0x30};
-			unsigned char patch2[] = {0xC2,0x30,0x2B,0xAB,0x7A,0xFA,0x68,0x28,0x58,0x40};
-			unsigned char patch3[] = {0xC2,0x30,0x48,0xDA,0x5A,0x8B,0x0B,0xE2,0x30,0x4B,0xAB};
-			
-			if((memcmp(patch1,Memory.ROM+0x9a3,sizeof(patch1))==0) &&
-				 (memcmp(patch2,Memory.ROM+0x9b5,sizeof(patch2))==0))
-			{
-				// phk - plb
-				memcpy(ROM+0x9a3,patch3,sizeof(patch3));
-				Memory.ROM[0x9bc]=0x40;
-			}
-		}
-	}
-
 
 	//// SRAM initial value
 

--- a/ppu.cpp
+++ b/ppu.cpp
@@ -332,7 +332,7 @@ void S9xUpdateIRQPositions (bool initial)
 	else if (PPU.HTimerEnabled && !PPU.VTimerEnabled)
 	{
 		Timings.NextIRQTimer = PPU.HTimerPosition;
-		if (CPU.Cycles > Timings.NextIRQTimer)
+		if (CPU.Cycles > Timings.NextIRQTimer - Timings.IRQTriggerCycles)
 			Timings.NextIRQTimer += Timings.H_Max;
 	}
 	else if (!PPU.HTimerEnabled && PPU.VTimerEnabled)
@@ -348,7 +348,7 @@ void S9xUpdateIRQPositions (bool initial)
 	}
 
 #ifdef DEBUGGER
-	S9xTraceFormattedMessage("--- IRQ Timer set %d cycles HTimer:%d Pos:%04d->%04d  VTimer:%d Pos:%03d->%03d",
+	S9xTraceFormattedMessage("--- IRQ Timer HC:%d VC:%d %s %d cycles HTimer:%d Pos:%04d->%04d  VTimer:%d Pos:%03d->%03d", CPU.Cycles, CPU.V_Counter, initial ? "set" : "recur",
 		Timings.NextIRQTimer, PPU.HTimerEnabled, PPU.IRQHBeamPos, PPU.HTimerPosition, PPU.VTimerEnabled, PPU.IRQVBeamPos, PPU.VTimerPosition);
 #endif
 }
@@ -1838,10 +1838,13 @@ uint8 S9xGetCPU (uint16 Address)
 				return ((byte & 0x80) | (OpenBus & 0x70) | Model->_5A22);
 
 			case 0x4211: // TIMEUP
-				byte = CPU.IRQLine ? 0x80 : 0;
-				CPU.IRQLine = FALSE;
-				CPU.IRQTransition = FALSE;
-				S9xUpdateIRQPositions(false);
+				byte = 0;
+				if (CPU.IRQLine)
+				{
+					byte = 0x80;
+					CPU.IRQLine = FALSE;
+					CPU.IRQTransition = FALSE;
+				}
 
 				return (byte | (OpenBus & 0x7f));
 


### PR DESCRIPTION
backport:
Remove IRQPending hack.
don't reset timer on 4211
Reset IRQLine on CLI.
Remove Aero the AcroBat 2 hack

libretro:
Fix mid-interlace frame drawing
Remove Marko's Magic Football hack (CLI fixed)